### PR TITLE
Fixing a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you are using Scala 2.9, add the following:
     
 If you are using Scala 2.10, add the following:    
 
-    libraryDependencies += "com.bizo" % "mighty-csv_2.10.1" % "0.2"
+    libraryDependencies += "com.bizo" % "mighty-csv_2.10" % "0.2"
 
 
 Reading CSV Files


### PR DESCRIPTION
in maven repos, there's no 2.10.1, only a 2.10
