### PR TITLE
Adds support for Scala 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,21 +2,20 @@ name := "mighty-csv"
 
 version := "0.2"
 
-scalaVersion := "2.11.2"
+scalaVersion := "2.12.4"
 
-crossScalaVersions := Seq("2.10.4", "2.9.3", "2.9.2", "2.9.1")
+crossScalaVersions := Seq("2.11.2", "2.10.4")
 
 retrieveManaged := true
 
 publishMavenStyle := true
 
-publishTo <<= version { (v: String) =>
-  val nexus = "https://oss.sonatype.org/"
-  if (v.trim.endsWith("SNAPSHOT")) 
-    Some("snapshots" at nexus + "content/repositories/snapshots") 
-  else
-    Some("releases"  at nexus + "service/local/staging/deploy/maven2")
-}
+lazy val nexus = "https://oss.sonatype.org/"
+publishTo := (version.value.trim.endsWith("SNAPSHOT") match {
+  case true => Some("snapshots" at nexus + "content/repositories/snapshots") 
+  case false => Some("releases" at nexus + "service/local/staging/deploy/maven2")
+  }
+)
 
 publishArtifact in Test := false
 
@@ -48,10 +47,12 @@ libraryDependencies += "net.sf.opencsv"%"opencsv"%"2.3"
 
 libraryDependencies += "junit"%"junit"%"4.8.2"%"test"
 
-libraryDependencies += PartialFunction.condOpt(CrossVersion.partialVersion(scalaVersion.value)){
-  case Some((2, scalaMajor)) if scalaMajor >= 10 =>
-    "org.scalatest" %% "scalatest" % "2.2.0" % "test"
-  case Some((2, scalaMajor)) if scalaMajor == 9 =>
-    "org.scalatest" %% "scalatest" % "1.9.2" % "test"
-}.get
-
+libraryDependencies += "org.scalatest"%%"scalatest"%"3.0.5"%"test"
+ 
+scalacOptions ++= Seq(
+  "-feature",
+  "-unchecked",
+  "-deprecation",
+  "-language:implicitConversions",
+  "-language:postfixOps"
+)

--- a/src/test/scala/com/bizo/mighty/csv/CSVDictReaderTest.scala
+++ b/src/test/scala/com/bizo/mighty/csv/CSVDictReaderTest.scala
@@ -1,12 +1,12 @@
 package com.bizo.mighty.csv
 
 import org.scalatest.{ WordSpec, BeforeAndAfterAll }
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 import collection.JavaConversions._
 import com.bizo.mighty.collection.ConsecutivelyGroupable._
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class CSVDictReaderTest extends WordSpec with ShouldMatchers with BeforeAndAfterAll {
+class CSVDictReaderTest extends WordSpec with Matchers with BeforeAndAfterAll {
 
   "CSVDictReader" should {
     "bind columns to headers" in {

--- a/src/test/scala/com/bizo/mighty/csv/CSVDictWriterTest.scala
+++ b/src/test/scala/com/bizo/mighty/csv/CSVDictWriterTest.scala
@@ -1,13 +1,13 @@
 package com.bizo.mighty.csv
 
 import org.scalatest.{ WordSpec, BeforeAndAfterAll }
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 import collection.JavaConversions._
 import java.io.StringWriter
 import au.com.bytecode.opencsv.{ CSVWriter => OpenCSVWriter }
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class CSVDictWriterTest extends WordSpec with ShouldMatchers with BeforeAndAfterAll {
+class CSVDictWriterTest extends WordSpec with Matchers with BeforeAndAfterAll {
   "CSVDictWriter" should {
     "properly write header row" in {
       val output = new StringWriter()

--- a/src/test/scala/com/bizo/mighty/csv/CSVReaderTest.scala
+++ b/src/test/scala/com/bizo/mighty/csv/CSVReaderTest.scala
@@ -1,12 +1,12 @@
 package com.bizo.mighty.csv
 
 import org.scalatest.{ WordSpec, BeforeAndAfterAll }
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 import collection.JavaConversions._
 import com.bizo.mighty.collection.ConsecutivelyGroupable._
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class CSVReaderTest extends WordSpec with ShouldMatchers with BeforeAndAfterAll {
+class CSVReaderTest extends WordSpec with Matchers with BeforeAndAfterAll {
   import CSVReaderTest._
   import CSVReader._
 
@@ -71,7 +71,7 @@ class CSVReaderTest extends WordSpec with ShouldMatchers with BeforeAndAfterAll 
           // test grouped row validity
           eGroup zip group foreach {
             case (g1, g2) =>
-              g1 should be === g2
+              g1 should be(g2)
           }
       }
     }

--- a/src/test/scala/com/bizo/mighty/csv/CSVWriterTest.scala
+++ b/src/test/scala/com/bizo/mighty/csv/CSVWriterTest.scala
@@ -1,14 +1,14 @@
 package com.bizo.mighty.csv
 
 import org.scalatest.{ WordSpec, BeforeAndAfterAll }
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 import collection.JavaConversions._
 import com.bizo.mighty.collection.ConsecutivelyGroupable._
 import java.io.StringWriter
 import au.com.bytecode.opencsv.{ CSVWriter => OpenCSVWriter }
 
 @org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
-class CSVWriterTest extends WordSpec with ShouldMatchers with BeforeAndAfterAll {
+class CSVWriterTest extends WordSpec with Matchers with BeforeAndAfterAll {
   "CSVWriter" should {
     "properly write one row at a time" in {
       val rows = Seq(List("a", "b", "c"), List("1", "2", "3"))


### PR DESCRIPTION
Hello 👋 

Thank you for making mighty-csv.

This PR adds support for Scala 2.12.

Support for 2.9 is dropped because of an API change in Scala Test (specifically the "Expired deprecations" for `ShouldMatch` outlined in [the release notes for Scala Test 3](http://www.scalatest.org/release_notes/3.0.0)).

I've run`+test` with success. 

I notice that `project` folder is excluded in `.gitignore`. For the record, I've used SBT 1.1 and Java 8 to test:

```
$ cat project/build.properties
sbt.version=1.1.0
```

There's one deprecation warning during compile:

```
CSVReader.scala:67:19: method erasure in trait ClassManifestDeprecatedApis is deprecated: Use runtimeClass instead
[warn]       manifest[T].erasure.getConstructors() foreach { constructor =>
[warn]                   ^
[warn] one warning found
```

If you like this PR, it'd be great to get a build published. Thank you again for mighty-csv.